### PR TITLE
Added prefixed event listeners (along with its detection).

### DIFF
--- a/gamepadtest.js
+++ b/gamepadtest.js
@@ -7,6 +7,7 @@
  * You should have received a copy of the CC0 Public Domain Dedication along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
  */
 var haveEvents = 'GamepadEvent' in window;
+var haveWebkitEvents = 'WebKitGamepadEvent' in window;
 var controllers = {};
 var rAF = window.mozRequestAnimationFrame ||
   window.webkitRequestAnimationFrame ||
@@ -107,6 +108,9 @@ function scangamepads() {
 if (haveEvents) {
   window.addEventListener("gamepadconnected", connecthandler);
   window.addEventListener("gamepaddisconnected", disconnecthandler);
+} else if (haveWebkitEvents) {
+  window.addEventListener("webkitgamepadconnected", connecthandler);
+  window.addEventListener("webkitgamepaddisconnected", disconnecthandler);
 } else {
   setInterval(scangamepads, 500);
 }


### PR DESCRIPTION
I run gamepad test on a Tizen SmartTV and it didn't detect the gamepad connecting and/or disconnecting. I discovered that the event listeners should also be prefixed with 'webkit'.