### PR TITLE
Avoid double-adding gamepads when scangamepads finds them first

### DIFF
--- a/gamepadtest.js
+++ b/gamepadtest.js
@@ -95,12 +95,8 @@ function updateStatus() {
 function scangamepads() {
   var gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads() : []);
   for (var i = 0; i < gamepads.length; i++) {
-    if (gamepads[i]) {
-      if (!(gamepads[i].index in controllers)) {
-        addgamepad(gamepads[i]);
-      } else {
-        controllers[gamepads[i].index] = gamepads[i];
-      }
+    if (gamepads[i] && (gamepads[i].index in controllers)) {
+      controllers[gamepads[i].index] = gamepads[i];
     }
   }
 }


### PR DESCRIPTION
If we get the gamepadconnected event after scangamepads sees that there is a new gamepad connected, we'll call addgamepad twice with the same gamepad and create an extra non-functional row for it in the display. Instead, have scangamepads only update state for pads that have already been added.