### PR TITLE
Added support for the 'touched' button attribute

### DIFF
--- a/gamepadtest.js
+++ b/gamepadtest.js
@@ -70,16 +70,22 @@ function updateStatus() {
       var b = buttons[i];
       var val = controller.buttons[i];
       var pressed = val == 1.0;
+      var touched = false;
       if (typeof(val) == "object") {
         pressed = val.pressed;
+        if ('touched' in val) {
+          touched = val.touched;
+        }
         val = val.value;
       }
       var pct = Math.round(val * 100) + "%";
       b.style.backgroundSize = pct + " " + pct;
+      b.className = "button";
       if (pressed) {
-        b.className = "button pressed";
-      } else {
-        b.className = "button";
+        b.className += " pressed";
+      }
+      if (touched) {
+        b.className += " touched";
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -15,8 +15,12 @@ You should have received a copy of the CC0 Public Domain Dedication along with t
 -->
 <script type="text/javascript" src="gamepadtest.js"></script>
 <style>
-.buttons, .axes {
+.axes {
   padding: 1em;
+}
+
+.buttons {
+  margin-left: 1em;
 }
 
 /*meter*/.axis {
@@ -25,6 +29,9 @@ You should have received a copy of the CC0 Public Domain Dedication along with t
 }
 
 .button {
+  display: inline-block;
+  width: 1em;
+  text-align: center;
   padding: 1em;
   border-radius: 20px;
   border: 1px solid black;
@@ -36,6 +43,16 @@ You should have received a copy of the CC0 Public Domain Dedication along with t
 
 .pressed {
   border: 1px solid red;
+}
+
+.touched::after {
+  content: "touch";
+  display: block;
+  position: absolute;
+  margin-top: -0.2em;
+  margin-left: -0.5em;
+  font-size: 0.8em;
+  opacity: 0.7;
 }
 </style>
 </head>


### PR DESCRIPTION
This is a pretty minor change that adds support for showing that a button has been "touched", as described in the [gamepad spec](https://w3c.github.io/gamepad/#dom-gamepadbutton-touched). The touched state is visualized as the word "touch" appearing below the button number. If the browser does not implement the `touched` attribute this visualization is ignored.